### PR TITLE
Added failling test

### DIFF
--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+class SkipSelf {
+    public function takesSelf(self $code): bool
+    {
+        return true;
+    }
+
+    static public function run(SkipSelf $self): void
+    {
+        $self->takesSelf(new SkipSelf());
+    }
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -140,6 +140,10 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/ThisPassedFromInterface.php',
             __DIR__ . '/Source/ExpectedThisType/CallByThisFromInterface.php',
         ], [[$argErrorMessage, 11]]];
+
+        yield [[
+            __DIR__ . '/Fixture/SkipSelf.php',
+        ], []];
     }
 
     /**


### PR DESCRIPTION
no errors should be emitted when calling a instance of the same class to a method expecting `self`