### PR TITLE
 [TypePerfect] Skip self on NarrowPublicClassMethodParamTypeRule 

### DIFF
--- a/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
+++ b/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
@@ -65,7 +65,7 @@ final readonly class PublicClassMethodParamTypesCollector implements Collector
             return null;
         }
 
-        $printedParamTypesString = $this->collectorMetadataPrinter->printParamTypesToString($node);
+        $printedParamTypesString = $this->collectorMetadataPrinter->printParamTypesToString($node, $classReflection->getName());
         return [$classReflection->getName(), $methodName, $printedParamTypesString, $node->getLine()];
     }
 }

--- a/src/Rules/NarrowPublicClassMethodParamTypeRule.php
+++ b/src/Rules/NarrowPublicClassMethodParamTypeRule.php
@@ -151,9 +151,9 @@ final readonly class NarrowPublicClassMethodParamTypeRule implements Rule
     private function flattenCollectedData(array $methodCallablesByFilePath): array
     {
         $methodFirstClassCallables = [];
-        foreach ($methodCallablesByFilePath as $collectedData) {
-            foreach ($collectedData as $collectedItem) {
-                $methodFirstClassCallables[] = $collectedItem[0];
+        foreach ($methodCallablesByFilePath as $methodCallables) {
+            foreach ($methodCallables as $methodCallable) {
+                $methodFirstClassCallables[] = $methodCallable[0];
             }
         }
 

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+class SkipSelf {
+    public function takesSelf(self $code): bool
+    {
+        return true;
+    }
+
+    static public function run(SkipSelf $self): void
+    {
+        $self->takesSelf(new SkipSelf());
+    }
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -140,6 +140,10 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/ThisPassedFromInterface.php',
             __DIR__ . '/Source/ExpectedThisType/CallByThisFromInterface.php',
         ], [[$argErrorMessage, 11]]];
+
+        yield [[
+            __DIR__ . '/Fixture/SkipSelf.php',
+        ], []];
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/rectorphp/type-perfect/pull/3