### PR TITLE
[Rules] Enable NoEmptyOnObjectRule and make same logic on possible undefined variable

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -18,6 +18,7 @@ rules:
     - Rector\TypePerfect\Rules\NoParamTypeRemovalRule
     - Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule
     - Rector\TypePerfect\Rules\NoIssetOnObjectRule
+    - Rector\TypePerfect\Rules\NoEmptyOnObjectRule
 
     # turn on by the group name
 

--- a/tests/Rules/NoEmptyOnObjectRule/Fixture/EmptyOnObject.php
+++ b/tests/Rules/NoEmptyOnObjectRule/Fixture/EmptyOnObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+use stdClass;
+
+final class EmptyOnObject
+{
+    public function run()
+    {
+        $object = null;
+
+        if (mt_rand(0, 100)) {
+            $object = new stdClass();
+        }
+
+        if (!empty($object)) {
+            return $object;
+        }
+    }
+}

--- a/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArray.php
+++ b/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArray.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+final class SkipEmptyOnArray
+{
+    public function run(array $values)
+    {
+        if (!empty($values[9])) {
+            return $values[9];
+        }
+    }
+}

--- a/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArrayNestedOnObject.php
+++ b/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArrayNestedOnObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+
+final class SkipEmptyOnArrayNestedOnObject
+{
+    public function run(MethodCall $methodCall)
+    {
+        if (!empty($methodCall->args[9])) {
+            return $methodCall->args[9];
+        }
+    }
+}

--- a/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
+++ b/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+final class SkipPossibleUndefinedVariable
+{
+    public function run(bool $condition)
+    {
+        if ($condition) {
+            $object = new \stdClass();
+        }
+
+        if (!empty($object)) {
+            $object->foo = 'bar';
+        }
+    }
+}

--- a/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
+++ b/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoEmptyOnObjectRule;
+
+final class NoEmptyOnObjectRuleTest extends RuleTestCase
+{
+    /**
+     * @param mixed[] $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/EmptyOnObject.php', [[NoEmptyOnObjectRule::ERROR_MESSAGE, 19]]];
+
+        yield [__DIR__ . '/Fixture/SkipEmptyOnArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipEmptyOnArrayNestedOnObject.php', []];
+        yield [__DIR__ . '/Fixture/SkipPossibleUndefinedVariable.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoEmptyOnObjectRule::class);
+    }
+}


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/type-perfect/pull/14

for `NoIssetOnObjectRule`, this PR enable `NoEmptyOnObjectRule` and make same logic on possible undefined variable