### PR TITLE
[Rules] Skip Closure/callable on NarrowPublicClassMethodParamTypeRule

### DIFF
--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -100,6 +100,7 @@ final readonly class CollectorMetadataPrinter
             }
 
             $printedParamType = $this->printerStandard->prettyPrint([$paramType]);
+            $printedParamType = str_replace('\Closure', 'callable', $printedParamType);
             $printedParamType = ltrim($printedParamType, '\\');
             $printedParamType = str_replace('|\\', '|', $printedParamType);
 

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipCallable.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipCallable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+final class SkipCallable
+{
+    public function map(callable $mapper): array
+    {
+        return [];
+    }
+
+    public function run()
+    {
+        $this->map(function () {});
+    }
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClosure.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClosure.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+final class SkipClosure
+{
+    public function map(\Closure $mapper): array
+    {
+        return [];
+    }
+
+    public function run()
+    {
+        $this->map(function () {});
+    }
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -145,6 +145,14 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/SkipSelf.php',
         ], []];
 
+        yield [[
+            __DIR__ . '/Fixture/SkipClosure.php',
+        ], []];
+
+        yield [[
+            __DIR__ . '/Fixture/SkipCallable.php',
+        ], []];
+
         $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeRule::ERROR_MESSAGE, 'int');
         yield [[
             __DIR__ . '/Fixture/HandleDefaultValue.php',


### PR DESCRIPTION
Fixes https://github.com/rectorphp/type-perfect/issues/9