### PR TITLE
NarrowPublicClassMethodParamTypeRule: Added failling test-case

### DIFF
--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipPhpDoc.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipPhpDoc.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+final class SkipPhpDoc
+{
+    public function called($node)
+    {
+    }
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -26,6 +26,12 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
 
     public static function provideData(): Iterator
     {
+        // skip phpdoc types
+        yield [[
+            __DIR__ . '/Fixture/SkipPhpDoc.php',
+            __DIR__ . '/Source/SkipPhpDoc/CallByPhpDoc.php',
+        ], []];
+
         yield [[__DIR__ . '/Fixture/SkipNonPublicClassMethod.php'], []];
 
         // skip first class callables as anything can be passed there

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipPhpDoc/CallByPhpDoc.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipPhpDoc/CallByPhpDoc.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedThisType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipPhpDoc;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipThisPassedExactType;
+
+final class CallByPhpDoc
+{
+    /**
+     * @param int $i
+     */
+    public function run(SkipPhpDoc $skipPhpDoc, $i): void
+    {
+        $skipPhpDoc->called($i);
+    }
+}


### PR DESCRIPTION
`NarrowPublicClassMethodParamTypeRule` should not suggest a addition of a type based on phpdoc