### PR TITLE
NoParamTypeRemovalRule: Skip constructors

### DIFF
--- a/src/Rules/NoParamTypeRemovalRule.php
+++ b/src/Rules/NoParamTypeRemovalRule.php
@@ -48,6 +48,10 @@ final readonly class NoParamTypeRemovalRule implements Rule
         }
 
         $classMethodName = (string) $node->name;
+        if ($classMethodName === '__construct') {
+            return [];
+        }
+
         $parentClassMethodReflection = $this->methodNodeAnalyser->matchFirstParentClassMethod($scope, $classMethodName);
         if (! $parentClassMethodReflection instanceof PhpMethodReflection) {
             return [];

--- a/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
+++ b/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
 
-class SkipConstruct extends ParentClass
+class SkipConstruct extends ParentConstructorClass
 {
     public function __construct($someArg, $someOther)
     {
@@ -12,7 +12,7 @@ class SkipConstruct extends ParentClass
     }
 }
 
-class ParentClass
+class ParentConstructorClass
 {
     public function __construct(string $string, int $int)
     {

--- a/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
+++ b/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class SkipConstruct extends ParentClass
+{
+    public function __construct($someArg, $someOther)
+    {
+        parent::__construct('foo', 4);
+    }
+}
+
+class ParentClass
+{
+    public function __construct(string $string, int $int)
+    {
+    }
+}

--- a/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
+++ b/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
@@ -23,6 +23,7 @@ final class NoParamTypeRemovalRuleTest extends RuleTestCase
 
     public static function provideData(): Iterator
     {
+        yield [__DIR__ . '/Fixture/SkipConstruct.php', []];
         yield [__DIR__ . '/Fixture/SkipPhpDocType.php', []];
         yield [__DIR__ . '/Fixture/SkipPresentType.php', []];
         yield [__DIR__ . '/Fixture/SkipNoType.php', []];


### PR DESCRIPTION
constructors - in contrast to regular methods - are allowed to have different argument orders and types