### PR TITLE
NarrowPublicClassMethodParamTypeRuleTest: Skip array-generics failling test

### DIFF
--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipArrayGenerics.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipArrayGenerics.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+class SkipArrayGenerics
+{
+    public function run(array $aArray = [])
+    {
+    }
+
+}

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -161,6 +161,12 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
         yield [[
             __DIR__ . '/Fixture/HandleDefaultValue.php',
         ], [[$argErrorMessage, 15]]];
+
+        yield [[
+            __DIR__ . '/Fixture/SkipArrayGenerics.php',
+            __DIR__ . '/Source/ArrayCaller.php',
+        ], []];
+
     }
 
     /**

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ArrayCaller.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ArrayCaller.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\PublicDoubleShot;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipArrayGenerics;
+
+final class ArrayCaller
+{
+    public function doRun(SkipArrayGenerics $r) {
+        $r->run(['hello' => 'abc']);
+    }
+
+    public function doRun2(SkipArrayGenerics $r) {
+        $r->run();
+    }
+
+}


### PR DESCRIPTION
failling test for https://github.com/rectorphp/type-perfect/issues/34