### PR TITLE
Early return Collectors when narrow-param is disabled

### DIFF
--- a/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
+++ b/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Matcher\Collector\PublicClassMethodMatcher;
 use Rector\TypePerfect\PhpDoc\ApiDocStmtAnalyzer;
 use Rector\TypePerfect\Printer\CollectorMetadataPrinter;
@@ -21,7 +22,8 @@ final readonly class PublicClassMethodParamTypesCollector implements Collector
     public function __construct(
         private ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
         private PublicClassMethodMatcher $publicClassMethodMatcher,
-        private CollectorMetadataPrinter $collectorMetadataPrinter
+        private CollectorMetadataPrinter $collectorMetadataPrinter,
+        private Configuration $configuration
     ) {
     }
 
@@ -36,6 +38,10 @@ final readonly class PublicClassMethodParamTypesCollector implements Collector
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
         if ($node->params === []) {
             return null;
         }

--- a/src/Collector/MethodCall/MethodCallArgTypesCollector.php
+++ b/src/Collector/MethodCall/MethodCallArgTypesCollector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ExtendedMethodReflection;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Matcher\ClassMethodCallReferenceResolver;
 use Rector\TypePerfect\Printer\CollectorMetadataPrinter;
 use Rector\TypePerfect\ValueObject\MethodCallReference;
@@ -22,6 +23,7 @@ final readonly class MethodCallArgTypesCollector implements Collector
     public function __construct(
         private ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
         private CollectorMetadataPrinter $collectorMetadataPrinter,
+        private Configuration $configuration
     ) {
     }
 
@@ -36,6 +38,10 @@ final readonly class MethodCallArgTypesCollector implements Collector
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
         if ($node->isFirstClassCallable() || $node->getArgs() === [] || ! $node->name instanceof Identifier) {
             return null;
         }

--- a/src/Collector/MethodCallableNode/MethodCallableCollector.php
+++ b/src/Collector/MethodCallableNode/MethodCallableCollector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\MethodCallableNode;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Matcher\ClassMethodCallReferenceResolver;
 use Rector\TypePerfect\ValueObject\MethodCallReference;
 
@@ -22,6 +23,7 @@ final readonly class MethodCallableCollector implements Collector
 {
     public function __construct(
         private ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
+        private Configuration $configuration
     ) {
     }
 
@@ -36,6 +38,10 @@ final readonly class MethodCallableCollector implements Collector
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
         $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, true);
         if (! $classMethodCallReference instanceof MethodCallReference) {
             return null;


### PR DESCRIPTION
collectors store their data in the PHPStan result cache. we shouldn't pollute the result cache with data if we don't need it.

looking at the sources it seems these 3 collectors are only used for `NarrowPublicClassMethodParamTypeRule` and this rule has a configuration flag to early return if not enabled.

with this PR we now use the same configuration flag to early return in the related collectors

----

this PR came together because  it turned out that one of the `type-perfect` collectors was by-far the most result-cache polluting component in our project:

```
mstaab@NB-COMPLEX-61 MINGW64 ~/AppData/Local/Temp/phpstan
$ grep 'collectorType' resultCache.php  > collectors.txt

mstaab@NB-COMPLEX-61 MINGW64 ~/AppData/Local/Temp/phpstan
$ sort collectors.txt | uniq -c
    283        'collectorType' => 'PHPStan\\Rules\\DeadCode\\ConstructorWithoutImpurePointsCollector',
      1        'collectorType' => 'PHPStan\\Rules\\DeadCode\\FunctionWithoutImpurePointsCollector',
    558        'collectorType' => 'PHPStan\\Rules\\DeadCode\\MethodWithoutImpurePointsCollector',
    351        'collectorType' => 'PHPStan\\Rules\\DeadCode\\PossiblyPureFuncCallCollector',
    391        'collectorType' => 'PHPStan\\Rules\\DeadCode\\PossiblyPureMethodCallCollector',
    133        'collectorType' => 'PHPStan\\Rules\\DeadCode\\PossiblyPureStaticCallCollector',
      3        'collectorType' => 'PHPStan\\Rules\\Traits\\TraitDeclarationCollector',
     34        'collectorType' => 'PHPStan\\Rules\\Traits\\TraitUseCollector',
    947        'collectorType' => 'Rector\\TypePerfect\\Collector\\ClassMethod\\PublicClassMethodParamTypesCollector',
   4765        'collectorType' => 'Rector\\TypePerfect\\Collector\\MethodCall\\MethodCallArgTypesCollector',
```

after his PR the result-cache of said project shrunk by ~16% in file-size - because we don't use `narrow_param` in our projects - which in turn makes phpstan analysis faster and less memory hungry