### PR TITLE
Test standalone install also on php 8.1

### DIFF
--- a/build/target-repository/.github/workflows/standalone_install.yaml
+++ b/build/target-repository/.github/workflows/standalone_install.yaml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
         steps:
             # prepare empty composer.json that allows the phpstan extension plugin


### PR DESCRIPTION
PHP 8.1 is the newest version which requires downgrading (as the source is stored in the repo with 8.2+)