### PR TITLE
Updates for PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "^2.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "nikic/php-parser": "^4.19",
+        "nikic/php-parser": "^5.0",
         "symplify/phpstan-extensions": "^11.4",
         "symplify/rule-doc-generator": "^12.1",
         "phpunit/phpunit": "^10.5",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,16 @@ parameters:
 
         # overly detailed generics
         - '#Rector\\TypePerfect\\Tests\\Rules\\(.*?) generic (class|interface)#'
+
+        -
+            identifier: phpstanApi.instanceofType
+            paths:
+                - src/Printer/CollectorMetadataPrinter.php
+                - src/Rules/NarrowPrivateClassMethodParamTypeRule.php
+                - src/Rules/NoArrayAccessOnObjectRule.php
+                - src/Rules/ReturnNullOverFalseRule.php
+
+        -
+            identifier: phpstanApi.instanceofAssumption
+            paths:
+                - src/Rules/NoParamTypeRemovalRule.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,4 +19,3 @@ parameters:
 
         # overly detailed generics
         - '#Rector\\TypePerfect\\Tests\\Rules\\(.*?) generic (class|interface)#'
-        - '#Method Rector\\TypePerfect\\Tests\\Rules\\(.*?)testRule\(\) has parameter \$expectedErrorsWithLines with no value type specified in iterable type array#'

--- a/src/Matcher/ClassMethodCallReferenceResolver.php
+++ b/src/Matcher/ClassMethodCallReferenceResolver.php
@@ -40,12 +40,12 @@ final class ClassMethodCallReferenceResolver
             return null;
         }
 
-        if (! $callerType instanceof TypeWithClassName) {
+        if (count($callerType->getObjectClassNames()) !== 1) {
             return null;
         }
 
         // move to the class where method is defined, e.g. parent class defines the method, so it should be checked there
-        $className = $callerType->getClassName();
+        $className = $callerType->getObjectClassNames()[0];
         $methodNameString = $methodName->toString();
 
         return new MethodCallReference($className, $methodNameString);

--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -13,15 +13,12 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType;
+use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\BooleanType;
-use PHPStan\Type\ClassStringType;
 use PHPStan\Type\ClosureType;
-use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -35,9 +32,11 @@ use Rector\TypePerfect\Enum\Types\ResolvedTypes;
 
 final readonly class CollectorMetadataPrinter
 {
+    private Standard $printer;
+
     public function __construct(
-        private Printer $printer
     ) {
+        $this->printer = new Standard();
     }
 
     public function printArgTypesAsString(MethodCall $methodCall, ExtendedMethodReflection $extendedMethodReflection, Scope $scope): string
@@ -54,7 +53,6 @@ final readonly class CollectorMetadataPrinter
                 return ResolvedTypes::UNKNOWN_TYPES;
             }
 
-            // @phpstan-ignore phpstanApi.instanceofType
             if ($argType instanceof IntersectionType) {
                 return ResolvedTypes::UNKNOWN_TYPES;
             }

--- a/src/Printer/NodeComparator.php
+++ b/src/Printer/NodeComparator.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Printer;
 
 use PhpParser\Node;
-use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Node\Printer\Printer;
 
 final readonly class NodeComparator
 {
     public function __construct(
-        private Standard $standard
+        private Printer $printer
     ) {
     }
 
@@ -20,6 +20,6 @@ final readonly class NodeComparator
         $firstNode->setAttribute('comments', null);
         $secondNode->setAttribute('comments', null);
 
-        return $this->standard->prettyPrint([$firstNode]) === $this->standard->prettyPrint([$secondNode]);
+        return $this->printer->prettyPrint([$firstNode]) === $this->printer->prettyPrint([$secondNode]);
     }
 }

--- a/src/Reflection/ReflectionParser.php
+++ b/src/Reflection/ReflectionParser.php
@@ -11,7 +11,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use PhpParser\PhpVersion;
 use PHPStan\Reflection\ClassReflection;
 use Throwable;
 
@@ -27,7 +26,7 @@ final class ReflectionParser
     public function __construct()
     {
         $parserFactory = new ParserFactory();
-        $this->parser = $parserFactory->createForVersion(PhpVersion::fromString('7.4'));
+        $this->parser = $parserFactory->createForNewestSupportedVersion();
     }
 
     public function parseClassReflection(ClassReflection $classReflection): ?ClassLike

--- a/src/Reflection/ReflectionParser.php
+++ b/src/Reflection/ReflectionParser.php
@@ -11,6 +11,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
 use PHPStan\Reflection\ClassReflection;
 use Throwable;
 
@@ -26,7 +27,7 @@ final class ReflectionParser
     public function __construct()
     {
         $parserFactory = new ParserFactory();
-        $this->parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+        $this->parser = $parserFactory->createForVersion(PhpVersion::fromString('7.4'));
     }
 
     public function parseClassReflection(ClassReflection $classReflection): ?ClassLike

--- a/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
+++ b/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
@@ -110,10 +110,6 @@ final readonly class NarrowPrivateClassMethodParamTypeRule implements Rule
                 continue;
             }
 
-            if (! $arg instanceof Arg) {
-                continue;
-            }
-
             $paramRuleError = $this->validateParam($param, $position, $arg->value, $scope);
             if (! $paramRuleError instanceof RuleError) {
                 continue;
@@ -149,6 +145,7 @@ final readonly class NarrowPrivateClassMethodParamTypeRule implements Rule
             return null;
         }
 
+        // @phpstan-ignore phpstanApi.instanceofType
         if ($argType instanceof IntersectionType) {
             return null;
         }

--- a/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
+++ b/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
@@ -145,7 +145,6 @@ final readonly class NarrowPrivateClassMethodParamTypeRule implements Rule
             return null;
         }
 
-        // @phpstan-ignore phpstanApi.instanceofType
         if ($argType instanceof IntersectionType) {
             return null;
         }

--- a/src/Rules/NarrowReturnObjectTypeRule.php
+++ b/src/Rules/NarrowReturnObjectTypeRule.php
@@ -94,8 +94,11 @@ final readonly class NarrowReturnObjectTypeRule implements Rule
             return [];
         }
 
-        /** @var TypeWithClassName $returnExprType */
-        $errorMessage = sprintf(self::ERROR_MESSAGE, $returnExprType->getClassName());
+        if (count($returnExprType->getObjectClassNames()) !== 1) {
+            return [];
+        }
+
+        $errorMessage = sprintf(self::ERROR_MESSAGE, $returnExprType->getObjectClassNames()[0]);
 
         return [
             RuleErrorBuilder::message($errorMessage)
@@ -127,15 +130,14 @@ final readonly class NarrowReturnObjectTypeRule implements Rule
 
     private function shouldSkipReturnExprType(Type $type): bool
     {
-        if (! $type instanceof TypeWithClassName) {
+        if (count($type->getObjectClassNames()) !== 1) {
             return true;
         }
 
-        $classReflection = $type->getClassReflection();
-        if (! $classReflection instanceof ClassReflection) {
+        if (count($type->getObjectClassReflections()) !== 1) {
             return true;
         }
 
-        return $classReflection->isAnonymous();
+        return $type->getObjectClassReflections()[0]->isAnonymous();
     }
 }

--- a/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/src/Rules/NoArrayAccessOnObjectRule.php
@@ -43,7 +43,6 @@ final class NoArrayAccessOnObjectRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         $varType = $scope->getType($node->var);
-        // @phpstan-ignore phpstanApi.instanceofType
         if (! $varType instanceof ObjectType) {
             return [];
         }

--- a/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/src/Rules/NoArrayAccessOnObjectRule.php
@@ -43,6 +43,7 @@ final class NoArrayAccessOnObjectRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         $varType = $scope->getType($node->var);
+        // @phpstan-ignore phpstanApi.instanceofType
         if (! $varType instanceof ObjectType) {
             return [];
         }

--- a/src/Rules/NoMixedMethodCallerRule.php
+++ b/src/Rules/NoMixedMethodCallerRule.php
@@ -6,7 +6,7 @@ namespace Rector\TypePerfect\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Node\Printer\Printer;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
@@ -27,7 +27,7 @@ final readonly class NoMixedMethodCallerRule implements Rule
     public const ERROR_MESSAGE = 'Mixed variable in a `%s->...()` can skip important errors. Make sure the type is known';
 
     public function __construct(
-        private Standard $printerStandard,
+        private Printer $printer,
         private Configuration $configuration,
     ) {
     }
@@ -65,7 +65,7 @@ final readonly class NoMixedMethodCallerRule implements Rule
             return [];
         }
 
-        $printedMethodCall = $this->printerStandard->prettyPrintExpr($node->var);
+        $printedMethodCall = $this->printer->prettyPrintExpr($node->var);
 
         return [
             RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $printedMethodCall))

--- a/src/Rules/NoMixedPropertyFetcherRule.php
+++ b/src/Rules/NoMixedPropertyFetcherRule.php
@@ -6,7 +6,7 @@ namespace Rector\TypePerfect\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Node\Printer\Printer;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
@@ -26,7 +26,7 @@ final readonly class NoMixedPropertyFetcherRule implements Rule
     public const ERROR_MESSAGE = 'Mixed property fetch in a "%s->..." can skip important errors. Make sure the type is known';
 
     public function __construct(
-        private Standard $standard,
+        private Printer $printer,
         private Configuration $configuration,
     ) {
     }
@@ -54,7 +54,7 @@ final readonly class NoMixedPropertyFetcherRule implements Rule
             return [];
         }
 
-        $printedVar = $this->standard->prettyPrintExpr($node->var);
+        $printedVar = $this->printer->prettyPrintExpr($node->var);
 
         return [
             RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $printedVar))

--- a/src/Rules/NoParamTypeRemovalRule.php
+++ b/src/Rules/NoParamTypeRemovalRule.php
@@ -55,7 +55,6 @@ final readonly class NoParamTypeRemovalRule implements Rule
         }
 
         $parentClassMethodReflection = $this->methodNodeAnalyser->matchFirstParentClassMethod($scope, $classMethodName);
-        // @phpstan-ignore phpstanApi.instanceofAssumption
         if (! $parentClassMethodReflection instanceof PhpMethodReflection) {
             return [];
         }

--- a/src/Rules/NoParamTypeRemovalRule.php
+++ b/src/Rules/NoParamTypeRemovalRule.php
@@ -55,6 +55,7 @@ final readonly class NoParamTypeRemovalRule implements Rule
         }
 
         $parentClassMethodReflection = $this->methodNodeAnalyser->matchFirstParentClassMethod($scope, $classMethodName);
+        // @phpstan-ignore phpstanApi.instanceofAssumption
         if (! $parentClassMethodReflection instanceof PhpMethodReflection) {
             return [];
         }

--- a/src/Rules/ReturnNullOverFalseRule.php
+++ b/src/Rules/ReturnNullOverFalseRule.php
@@ -13,7 +13,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use Rector\TypePerfect\Configuration;
 
@@ -74,7 +73,6 @@ final readonly class ReturnNullOverFalseRule implements Rule
             }
 
             $exprType = $scope->getType($return->expr);
-            // @phpstan-ignore phpstanApi.instanceofType
             if (! $exprType instanceof ConstantBooleanType) {
                 if ($exprType->isBoolean()->yes()) {
                     return [];

--- a/src/Rules/ReturnNullOverFalseRule.php
+++ b/src/Rules/ReturnNullOverFalseRule.php
@@ -74,8 +74,9 @@ final readonly class ReturnNullOverFalseRule implements Rule
             }
 
             $exprType = $scope->getType($return->expr);
+            // @phpstan-ignore phpstanApi.instanceofType
             if (! $exprType instanceof ConstantBooleanType) {
-                if ($exprType instanceof BooleanType) {
+                if ($exprType->isBoolean()->yes()) {
                     return [];
                 }
 

--- a/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
@@ -16,7 +16,7 @@ use Rector\TypePerfect\Rules\NarrowPrivateClassMethodParamTypeRule;
 final class NarrowPrivateClassMethodParamTypeRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorsWithLines): void

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -16,7 +16,7 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
 {
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void

--- a/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
+++ b/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
@@ -14,7 +14,7 @@ use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\SpecificCon
 final class NarrowReturnObjectTypeRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
+++ b/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
@@ -13,7 +13,7 @@ use Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule;
 final class NoArrayAccessOnObjectRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
+++ b/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
@@ -13,7 +13,7 @@ use Rector\TypePerfect\Rules\NoEmptyOnObjectRule;
 final class NoEmptyOnObjectRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
+++ b/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
@@ -13,7 +13,7 @@ use Rector\TypePerfect\Rules\NoIssetOnObjectRule;
 final class NoIssetOnObjectRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
+++ b/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
@@ -12,6 +12,9 @@ use Rector\TypePerfect\Rules\NoMixedMethodCallerRule;
 
 final class NoMixedMethodCallerRuleTest extends RuleTestCase
 {
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorsWithLines): void
     {

--- a/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
+++ b/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
@@ -12,6 +12,9 @@ use Rector\TypePerfect\Rules\NoMixedPropertyFetcherRule;
 
 final class NoMixedPropertyFetcherRuleTest extends RuleTestCase
 {
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorsWithLines): void
     {

--- a/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
+++ b/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
@@ -13,7 +13,7 @@ use Rector\TypePerfect\Rules\NoParamTypeRemovalRule;
 final class NoParamTypeRemovalRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
+++ b/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
@@ -13,7 +13,7 @@ use Rector\TypePerfect\Rules\ReturnNullOverFalseRule;
 final class ReturnNullOverFalseRuleTest extends RuleTestCase
 {
     /**
-     * @param mixed[] $expectedErrorMessagesWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void


### PR DESCRIPTION
Updates needed to update this to run with PHPStan 2.0

To install locally I had to remove the references to `rector/rector` and `symplify/phpstan-extensions` in composer.json. This should be updated once these dependencies are updated