### PR TITLE
Bump to PHPStan ^2.1.8 and change deprecated ClassReflection::isSubClassOf() to ClassReflection::is() for PHPStan ^2.1.8

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.8",
         "webmozart/assert": "^1.11"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.8",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -23,7 +23,7 @@ final class PublicClassMethodMatcher
         }
 
         foreach (self::SKIPPED_TYPES as $skippedType) {
-            if ($classReflection->isSubclassOf($skippedType)) {
+            if ($classReflection->is($skippedType)) {
                 return true;
             }
         }


### PR DESCRIPTION
Similar with rector-src PR:

- https://github.com/rectorphp/rector-src/pull/6775

`ClassReflection::isSubClassOf()` is deprecated in latest PHPStan 2.1.8

https://github.com/phpstan/phpstan/releases/tag/2.1.8

The allowed string to parameter is now changed to use method `ClassReflection::is(string $className)`