### PR TITLE
Fix PHPStan error

### DIFF
--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -88,7 +88,7 @@ final readonly class CollectorMetadataPrinter
         return implode('|', $stringArgTypes);
     }
 
-    public function printParamTypesToString(ClassMethod $classMethod, ?string $className): string
+    public function printParamTypesToString(ClassMethod $classMethod, string $className): string
     {
         $printedParamTypes = [];
         foreach ($classMethod->params as $param) {


### PR DESCRIPTION
fixes

```
➜  type-perfect git:(main) ✗ vendor/bin/phpstan            
Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port).
Note: Using configuration file /Users/m.staab/dvl/type-perfect/phpstan.neon.
 39/39 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   src/Printer/CollectorMetadataPrinter.php                                                                       
 ------ --------------------------------------------------------------------------------------------------------------- 
  91     Parameters should have "PhpParser\Node\Stmt\ClassMethod|string" types as the only types passed to this method  
         🪪  typePerfect.narrowPublicClassMethodParamType                                                               
         at src/Printer/CollectorMetadataPrinter.php:91                                                                 
 ------ --------------------------------------------------------------------------------------------------------------- 
 ```