### PR TITLE
Fix "types as the only types passed to this method" false positive on generic parameter types

### DIFF
--- a/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
+++ b/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
@@ -73,7 +73,8 @@ final readonly class PublicClassMethodParamTypesCollector implements Collector
 
         $printedParamTypesString = $this->collectorMetadataPrinter->printParamTypesToString(
             $node,
-            $classReflection->getName()
+            $classReflection,
+            $scope
         );
         return [$classReflection->getName(), $methodName, $printedParamTypesString, $node->getLine()];
     }

--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -15,8 +15,10 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
@@ -88,29 +90,53 @@ final readonly class CollectorMetadataPrinter
         return implode('|', $stringArgTypes);
     }
 
-    public function printParamTypesToString(ClassMethod $classMethod, string $className): string
+    public function printParamTypesToString(ClassMethod $classMethod, ClassReflection $classReflection, Scope $scope): string
     {
+        $className = $classReflection->getName();
+
+        $parametersReflection = [];
+        if ($classReflection->hasMethod($classMethod->name->name)) {
+            $methodReflection = $classReflection->getMethod($classMethod->name->name, $scope);
+            $variants = $methodReflection->getVariants();
+            if (count($variants) === 1) {
+                $parametersReflection = $variants[0]->getParameters();
+            }
+        }
+
         $printedParamTypes = [];
-        foreach ($classMethod->params as $param) {
+        foreach ($classMethod->params as $i => $param) {
             if ($param->type === null) {
                 $printedParamTypes[] = '';
                 continue;
             }
 
-            $paramType = $this->transformSelfToClassName($param->type, $className);
-            if ($paramType instanceof NullableType) {
-                // unite to phpstan type
-                $paramType = new UnionType([$paramType->type, new Identifier('null')]);
+            $phpdocType = null;
+            if (array_key_exists($i, $parametersReflection)) {
+                $paramphpdocType = $parametersReflection[$i]->getPhpDocType();
+                if (!$paramphpdocType instanceof MixedType) {
+                    $phpdocType = $paramphpdocType;
+                }
             }
 
-            if ($paramType instanceof UnionType || $paramType instanceof NodeIntersectionType) {
-                $paramType = $this->resolveSortedTypes($paramType, $className);
-            }
+            if ($phpdocType) {
+                $printedParamType = $this->printTypeToString($phpdocType);
+            } else {
+                $paramType = $this->transformSelfToClassName($param->type, $className);
 
-            $printedParamType = $this->standard->prettyPrint([$paramType]);
-            $printedParamType = str_replace('\Closure', 'callable', $printedParamType);
-            $printedParamType = ltrim($printedParamType, '\\');
-            $printedParamType = str_replace('|\\', '|', $printedParamType);
+                if ($paramType instanceof NullableType) {
+                    // unite to phpstan type
+                    $paramType = new UnionType([$paramType->type, new Identifier('null')]);
+                }
+
+                if ($paramType instanceof UnionType || $paramType instanceof NodeIntersectionType) {
+                    $paramType = $this->resolveSortedTypes($paramType, $className);
+                }
+
+                $printedParamType = $this->standard->prettyPrint([$paramType]);
+                $printedParamType = str_replace('\Closure', 'callable', $printedParamType);
+                $printedParamType = ltrim($printedParamType, '\\');
+                $printedParamType = str_replace('|\\', '|', $printedParamType);
+            }
 
             // to avoid DateTime vs DateTimeImmutable vs DateTimeInterface conflicts
             $printedParamType = $this->normalizeDateTime($printedParamType);

--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -18,7 +18,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
@@ -90,8 +89,11 @@ final readonly class CollectorMetadataPrinter
         return implode('|', $stringArgTypes);
     }
 
-    public function printParamTypesToString(ClassMethod $classMethod, ClassReflection $classReflection, Scope $scope): string
-    {
+    public function printParamTypesToString(
+        ClassMethod $classMethod,
+        ClassReflection $classReflection,
+        Scope $scope
+    ): string {
         $className = $classReflection->getName();
 
         $parametersReflection = [];
@@ -113,7 +115,7 @@ final readonly class CollectorMetadataPrinter
             $phpdocType = null;
             if (array_key_exists($i, $parametersReflection)) {
                 $paramphpdocType = $parametersReflection[$i]->getPhpDocType();
-                if (!$paramphpdocType instanceof MixedType) {
+                if (! $paramphpdocType instanceof MixedType) {
                     $phpdocType = $paramphpdocType;
                 }
             }

--- a/src/Printer/CollectorMetadataPrinter.php
+++ b/src/Printer/CollectorMetadataPrinter.php
@@ -120,7 +120,7 @@ final readonly class CollectorMetadataPrinter
                 }
             }
 
-            if ($phpdocType) {
+            if ($phpdocType instanceof Type) {
                 $printedParamType = $this->printTypeToString($phpdocType);
             } else {
                 $paramType = $this->transformSelfToClassName($param->type, $className);

--- a/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipPassedGenerics.php
+++ b/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipPassedGenerics.php
@@ -15,10 +15,10 @@ class User
     public function doFoo(GenericA $g):void
     {
     }
+
+    /** @param GenericA<string> $g */
+    function doBar($g):void {
+        $this->doFoo($g);
+    }
 }
 
-/** @param GenericA<string> $g */
-function doFoo($g):void {
-    $user = new User();
-    $user->doFoo($g);
-}


### PR DESCRIPTION
fix reproducer for https://github.com/rectorphp/type-perfect/issues/59

---

for some reason I don't understand the test-suite only errors for this case on first-class callables, while in real world projects we see the same error on non-first-class-callables.

I verfied that this fix also fixes my real world project bug which is is reported on a non-first-class callable (as the test-case showcased before this PR)