### PR TITLE
Allow webmozart/assert to ^2.1

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.14"
+        "phpstan/phpstan": "^2.1.14",
+        "webmozart/assert": "^1.11 || ^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -5,8 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.14",
-        "webmozart/assert": "^1.11"
+        "phpstan/phpstan": "^2.1.14"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^2.1.30",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^2.1"
     },
     "require-dev": {
         "nikic/php-parser": "^5.6",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^2.1.30",
-        "webmozart/assert": "^2.1"
+        "webmozart/assert": "^1.11 || ^2.1"
     },
     "require-dev": {
         "nikic/php-parser": "^5.6",

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return RectorConfig::configure()
     ->withPhpSets()
@@ -18,4 +19,8 @@ return RectorConfig::configure()
     )
     ->withPaths([__DIR__ . '/config', __DIR__ . '/src', __DIR__ . '/tests'])
     ->withImportNames(removeUnusedImports: true)
-    ->withSkip(['*/Source/*', '*/Fixture/*']);
+    ->withSkip([
+        '*/Source/*',
+        '*/Fixture/*',
+        StringClassNameToClassConstantRector::class,
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -19,8 +19,4 @@ return RectorConfig::configure()
     )
     ->withPaths([__DIR__ . '/config', __DIR__ . '/src', __DIR__ . '/tests'])
     ->withImportNames(removeUnusedImports: true)
-    ->withSkip([
-        '*/Source/*',
-        '*/Fixture/*',
-        StringClassNameToClassConstantRector::class,
-    ]);
+    ->withSkip(['*/Source/*', '*/Fixture/*', StringClassNameToClassConstantRector::class]);

--- a/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\TypePerfect\Matcher\Collector;
 
-use PHPUnit\Framework\TestCase;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\TestCase;
 
 final class PublicClassMethodMatcher
 {

--- a/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -7,7 +7,6 @@ namespace Rector\TypePerfect\Matcher\Collector;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
-use PHPUnit\Framework\TestCase;
 
 final class PublicClassMethodMatcher
 {
@@ -15,7 +14,7 @@ final class PublicClassMethodMatcher
      * @var string[]
      */
     private const SKIPPED_TYPES = [
-        TestCase::class,
+        'PHPUnit\Framework\TestCase',
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ];
 

--- a/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\TypePerfect\Matcher\Collector;
 
+use PHPUnit\Framework\TestCase;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
@@ -14,7 +15,7 @@ final class PublicClassMethodMatcher
      * @var string[]
      */
     private const SKIPPED_TYPES = [
-        'PHPUnit\Framework\TestCase',
+        TestCase::class,
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ];
 

--- a/src/Rules/NoParamTypeRemovalRule.php
+++ b/src/Rules/NoParamTypeRemovalRule.php
@@ -82,8 +82,8 @@ final readonly class NoParamTypeRemovalRule implements Rule
 
     private function resolveParentParamType(PhpMethodReflection $phpMethodReflection, int $paramPosition): Type
     {
-        foreach ($phpMethodReflection->getVariants() as $variant) {
-            foreach ($variant->getParameters() as $parentParamPosition => $parameterReflectionWithPhpDoc) {
+        foreach ($phpMethodReflection->getVariants() as $extendedParametersAcceptor) {
+            foreach ($extendedParametersAcceptor->getParameters() as $parentParamPosition => $parameterReflectionWithPhpDoc) {
                 if ($paramPosition !== $parentParamPosition) {
                     continue;
                 }


### PR DESCRIPTION
Since downgrade release include `webmozart/assert` as well, this PR make allow both `^1.11` and `^2.1`, as the scoped vendor is not part of downgrade build.

to be able to be used on upgrade to webmozart/assert v2 at

- https://github.com/rectorphp/rector-src/pull/7819